### PR TITLE
Fix Windows Path Addition Bug

### DIFF
--- a/utils/shell_utils.py
+++ b/utils/shell_utils.py
@@ -171,11 +171,12 @@ def add_to_path(dirpath):
     """
     if not is_included_in_path(dirpath):
         if platform.system() == "Windows":
-            # Update PATH permanently for the user
+            # Update PATH permanently for the user using PowerShell
             path_dirs = os.environ["PATH"].split(";")
             path_dirs.append(dirpath)
             new_path = ";".join(path_dirs)
-            subprocess.run(['setx', 'PATH', new_path], shell=True)
+            powershell_command = f'[Environment]::SetEnvironmentVariable("Path", "{new_path}", "User")'
+            subprocess.run(["powershell", "-Command", powershell_command], shell=True)
 
             # Update PATH for the current session
             os.environ["PATH"] = new_path


### PR DESCRIPTION
## Description

This PR fixes a bug where CMD has a maximum of 1024 characters when using `setx`, so I swapped to using Powershell which doesn't have this limitation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have locally tested my code using the sandbox or my host machine
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
