### PR TITLE
Parallelize and improve sandbox copying process, tweaks

### DIFF
--- a/sandbox/start_sandbox.py
+++ b/sandbox/start_sandbox.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 
 # Scan this directory for all *.Dockerfile files
 dockerfiles = [f for f in os.listdir("./environments") if f.endswith(".Dockerfile")]
@@ -24,6 +25,21 @@ def get_operating_system_environments():
     Get a list of available operating system environments.
     """
     return list(dockerfile_dict.keys())
+
+
+def run_docker_build(command):
+    """
+    Run Docker build command with real-time output.
+    """
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    while True:
+        output = process.stdout.readline()
+        if output == '' and process.poll() is not None:
+            break
+        if output:
+            print(output.strip())
+    rc = process.poll()
+    return rc
 
 
 def get_local_dockerfile_path(os_name, variant):
@@ -81,37 +97,68 @@ def run_command(command, shell=False, display_output=False):
         return None
     else:
         proc = subprocess.run(command, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-        if proc.returncode != 0:
+        if proc.returncode != 0 and display_output:
             print(f"Error running command: {command}\n{proc.stderr}")
             sys.exit(1)
         return proc.stdout.strip()
 
 
+def copy_file_to_container(container_id, local_path, container_path):
+    target_subdir = os.path.dirname(container_path)
+    
+    # Check if the contents are different by reading
+    local_contents = open(local_path, "r").read()
+    container_contents = run_command(f"docker exec {container_id} cat {container_path}", shell=True, display_output=False)
+    
+    if "No such file or directory" not in container_contents and local_contents.strip() == container_contents.strip():
+        return
+    
+    print(f"Copying {local_path} to {container_path}...")
+    run_command(f"docker exec {container_id} mkdir -p {target_subdir}")
+    run_command(f"docker cp {local_path} {container_id}:{container_path}")
+
+    if "requirements.txt" in local_path:
+        print("Updating Python dependencies...")
+        run_command(f"docker exec {container_id} pip install -r {container_path}")
+
+
 def copy_files_to_container(container_id):
     """
-    Copy files from the local source directory to the container.
+    Copy files from the local source directory to the container in parallel.
     
     Args:
         container_id (str): The ID of the container to copy files to
     """
     
     # Define the local source directory and the target directory inside the container
-    src_dir = os.path.abspath(".")
+    src_dir = os.path.abspath("..")
     target_dir = "/app/"
+    
+    # List of tasks for parallel execution
+    tasks = []
 
-    # Walk through the local source directory and copy files to the container
+    # Walk through the local source directory and prepare copy tasks
     for root, _, files in os.walk(src_dir):
+        # Make sure it's not evenv
+        if any(substring in root for substring in ["venv", ".git", "sandbox"]):
+            continue
+        
         for file in files:
+            if ".py" not in file and file != "requirements.txt":
+                continue
+            
             local_path = os.path.join(root, file)
             relative_path = os.path.relpath(local_path, src_dir)
             container_path = os.path.join(target_dir, relative_path)
+            
+            container_path = container_path.replace("\\", "/")
+            
+            # Append tuple of arguments for the copy operation
+            tasks.append((container_id, local_path, container_path))
 
-            # Ensure the target directory exists inside the container
-            target_subdir = os.path.dirname(container_path)
-            run_command(f"docker exec {container_id} mkdir -p {target_subdir}", shell=True)
-
-            # Copy the file to the container
-            run_command(f"docker cp {local_path} {container_id}:{container_path}", shell=True)
+    # Execute copy tasks in parallel
+    with ThreadPoolExecutor() as executor:
+        executor.map(lambda args: copy_file_to_container(*args), tasks)
 
 
 def main(update=False, open_existing=False, os_name="ubuntu", is_root=False):
@@ -157,7 +204,7 @@ def main(update=False, open_existing=False, os_name="ubuntu", is_root=False):
         print(f"Building a new {os_name} sandbox environment...")
         
         # Build a new Docker image
-        run_command(f"docker build -t {container_name} -f {dockerfile_path} ..", shell=True, display_output=True)
+        run_docker_build(f"docker build -t {container_name} -f {dockerfile_path} .. --progress=plain")
 
         # Remove existing container if it exists
         if container_id:


### PR DESCRIPTION
## Description

This PR improves the `start_sandbox.py` update procedure by parallelizing the copy process and excluding unneeded directories. Docker build command output has also been fixed.

## Adds

- When `requirements.txt` is changed, run `pip install` in the container for when dependencies are added

## Modifications

- Parallelize the container copy process so it's quicker than one at a time
- Avoid directories like `venv`, `.git`, and `sandbox`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have locally tested my code using the sandbox or my host machine
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
